### PR TITLE
Fixed CVE job handling

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Batch_Upgrade.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Batch_Upgrade.json
@@ -69,6 +69,7 @@
 								"startCol": 0
 							}
 						],
+						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -82,6 +83,7 @@
 						"displayType": "ROW",
 						"h": 2,
 						"i": "caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
+						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -116,10 +118,11 @@
 						"h": 2,
 						"i": "caseinfoid-770ec200-98b1-11e9-97d7-ed26ef9e46c8",
 						"isVisible": true,
+						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
-						"name": "Running Upgrades",
+						"name": "Running Upgrades or Parent Incident",
 						"static": false,
 						"type": "linkedIncidents",
 						"w": 1,
@@ -182,6 +185,7 @@
 								"startCol": 0
 							}
 						],
+						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -224,6 +228,7 @@
 						"h": 2,
 						"i": "caseinfoid-36b83780-16a9-11ed-ab3c-5b8eb5d42a0c",
 						"items": [],
+						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Upgrade_Assurance_Layout.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Upgrade_Assurance_Layout.json
@@ -252,9 +252,19 @@
 								"index": 0,
 								"sectionItemType": "field",
 								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "postupgradereadinesscheckresult",
+								"height": 106,
+								"id": "457c96f0-47c0-11ee-b192-01822b22e90f",
+								"index": 1,
+								"listId": "caseinfoid-8cac1dd0-ea40-11ed-939f-4f8b882605d4",
+								"sectionItemType": "field",
+								"startCol": 0
 							}
 						],
-						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -281,7 +291,6 @@
 								"startCol": 0
 							}
 						],
-						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -336,7 +345,6 @@
 								"startCol": 4
 							}
 						],
-						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,
@@ -363,7 +371,6 @@
 								"startCol": 0
 							}
 						],
-						"maxH": null,
 						"maxW": 3,
 						"minH": 1,
 						"moved": false,

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Check_For_Open_CVEs.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Check_For_Open_CVEs.yml
@@ -1,5 +1,5 @@
 id: PAN-OS Network Operations - Check For Open CVEs
-version: 5
+version: 7
 vcShouldKeepItemLegacyProdMachine: false
 name: PAN-OS Network Operations - Check For Open CVEs
 description: This playbook uses the Palo Alto Networks Security Advisories integration,
@@ -39,10 +39,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "2":
     id: "2"
-    taskid: 975c45f2-c0be-48db-8c36-c9b42b1162d4
+    taskid: 2f8528b7-89b6-46c7-8fea-c9c68198ba37
     type: condition
     task:
-      id: 975c45f2-c0be-48db-8c36-c9b42b1162d4
+      id: 2f8528b7-89b6-46c7-8fea-c9c68198ba37
       version: -1
       name: Is the Advisories integration enabled?
       type: condition
@@ -66,20 +66,22 @@ tasks:
                 - - operator: isEqualString
                     left:
                       value:
-                        simple: modules.brand
-                      iscontext: true
-                    right:
-                      value:
-                        simple: Palo_Alto_Networks_Security_Advisories
-                - - operator: isEqualString
-                    left:
-                      value:
                         simple: modules.state
                       iscontext: true
                     right:
                       value:
                         simple: active
+                - - operator: isEqualString
+                    left:
+                      value:
+                        simple: modules.brand
+                      iscontext: true
+                    right:
+                      value:
+                        simple: Palo Alto Networks Security Advisories
             iscontext: true
+          right:
+            value: {}
     continueonerrortype: ""
     view: |-
       {
@@ -154,6 +156,9 @@ tasks:
       type: title
       iscommand: false
       brand: ""
+    nexttasks:
+      '#none#':
+      - "6"
     separatecontext: false
     continueonerrortype: ""
     view: |-
@@ -202,6 +207,35 @@ tasks:
     quietmode: 0
     isoversize: false
     isautoswitchedtoquietmode: false
+  "6":
+    id: "6"
+    taskid: dce2b9bb-22fa-45c4-8824-c2e61d84ae7c
+    type: regular
+    task:
+      id: dce2b9bb-22fa-45c4-8824-c2e61d84ae7c
+      version: -1
+      name: Close
+      description: commands.local.cmd.close.inv
+      script: Builtin|||closeInvestigation
+      type: regular
+      iscommand: true
+      brand: Builtin
+    separatecontext: false
+    continueonerrortype: ""
+    view: |-
+      {
+        "position": {
+          "x": 450,
+          "y": 880
+        }
+      }
+    note: false
+    timertriggers: []
+    ignoreworker: false
+    skipunavailable: false
+    quietmode: 0
+    isoversize: false
+    isautoswitchedtoquietmode: false
 view: |-
   {
     "linkLabelsPosition": {
@@ -209,7 +243,7 @@ view: |-
     },
     "paper": {
       "dimensions": {
-        "height": 755,
+        "height": 925,
         "width": 380,
         "x": 450,
         "y": 50

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Check_Version_for_CVEs.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Check_Version_for_CVEs.yml
@@ -1,5 +1,5 @@
 id: PAN-OS Network Operations - Check Version for CVEs
-version: 5
+version: 6
 vcShouldKeepItemLegacyProdMachine: false
 name: PAN-OS Network Operations - Check Version for CVEs
 description: Checks a specific version of software for any open CVEs, and if they
@@ -82,7 +82,7 @@ tasks:
       name: Check if this version is affected by any CVEs
       description: 'Checks if the given PAN-OS version number is affected by the given
         list of vulnerabilties. '
-      script: CheckPanosVersionAffected
+      scriptName: CheckPanosVersionAffected
       type: regular
       iscommand: false
       brand: ""
@@ -193,10 +193,10 @@ tasks:
     isautoswitchedtoquietmode: false
   "7":
     id: "7"
-    taskid: 04bd01f0-567a-46fb-86e0-f5abd4f0b129
+    taskid: c8694d2b-ed6c-43ac-87a9-457af67b24bf
     type: regular
     task:
-      id: 04bd01f0-567a-46fb-86e0-f5abd4f0b129
+      id: c8694d2b-ed6c-43ac-87a9-457af67b24bf
       version: -1
       name: Create Platform Upgrade Incident
       description: commands.local.cmd.create.inc
@@ -244,7 +244,7 @@ tasks:
       name:
         simple: Automatic CVE Remedation Upgrade - ${inputs.panos_version}
       panosnetworkoperationsdeviceupgradequery:
-        simple: panosnetworkoperationsrunningsoftwareversion:${inputs.panos_version}
+        simple: softwareversion:${inputs.panos_version}
       panosnetworkoperationsparentincidentid:
         simple: ${incident.id}
       type:

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Create_CVE_Relationships.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Create_CVE_Relationships.yml
@@ -82,7 +82,7 @@ tasks:
       name: Check if this version is affected by any CVEs
       description: Checks if the given PAN-OS version number is affected by the given
         list of vulnerabilties from the pan-advisories-get-advisories command.
-      script: CheckPanosVersionAffected
+      scriptName: CheckPanosVersionAffected
       type: regular
       iscommand: false
       brand: ""

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,5 +22,9 @@
 3. Configure the PAN-OS Device Management integration.
 4. Configure the PAN-OS Assurance Testing integration.
 
+Optionally:
+
+5. Configure the Palo Alto Networks Security Advisories Integration
+
 Now you should be done. You'll see your connected firewalls appear under Threat Intel, and be able to launch upgrades
 and assurance testing from there.

--- a/release.md
+++ b/release.md
@@ -1,3 +1,3 @@
 Fixes:
- * Fix incorrect handling of M- series appliances running in Panorama Mode
- * Add handle_proxy() to support XSOAR proxy sessions in both new integrations
+ * Fix bad input for CVE Check playbooks
+ * Fix bad indicator field spec in CVE Check playbook


### PR DESCRIPTION
## Fixes
 * Allowed users to once again use the CVE check playbooks to upgrade firewalls when a CVE is encountered, based on CVEs fetched by the "Security advisories' integration.