### PR TITLE
Only Perform HA Checks if HA is Configured

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -106,8 +106,10 @@ def run_readiness_checks(
             'ntp_sync',
             'candidate_config',
             'expired_licenses',
-            'ha'
         ]
+        # only include HA check if HA is enabled
+        if firewall.get_ha_configuration().get('enabled') == 'yes':
+            check_list.append('ha')
     custom_checks = []
 
     # Add the custom checks


### PR DESCRIPTION
## Description

For the default readiness check, only perform the HA check if HA is actually configured on the device

## Motivation and Context

When HA isn't configured, the readiness check will always fail.  Resolves #20 

## How Has This Been Tested?

Tested by performing readiness checks on HA and nonHA firewalls.


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
