### PR TITLE
Adding BGP peers to default snapshot

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -66,6 +66,7 @@ def run_snapshot(
             'content_version',
             'session_stats',
             'ip_sec_tunnels',
+            'bgp_peers',
         ]
 
     snapshot = checks.run_snapshots(snapshot_list)


### PR DESCRIPTION
## Description

Adding BGP peers to default snapshot

## Motivation and Context

For additional validations, BGP peers should be included in the default snapshot.  Resolves #24 

## How Has This Been Tested?

Performed upgrades on firewalls with BGP routing


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
