### PR TITLE
Device Upgrade new incident layout customizable assurance tests

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -267,6 +267,12 @@ def command_run_readiness_checks(panorama: Panorama):
         check_list.remove('dp_mp_clock_diff')
         check_list.append('planes_clock_sync')  # to match with upgrade assurance check type
 
+    # 'content_version' already match upgrade assurance check type
+
+    if 'dp_mp_clock_diff' in check_list:
+        check_list.remove('dp_mp_clock_diff')
+        check_list.append('planes_clock_sync')  # to match with upgrade assurance check type
+
     # this will set it to None if emptry string or not provided
     dp_mp_clock_diff = arg_to_number(args.get('dp_mp_clock_diff'), required=False)
     if args.get('dp_mp_clock_diff') is not None:
@@ -275,6 +281,21 @@ def command_run_readiness_checks(panorama: Panorama):
     if 'ipsec_tunnel' in check_list:
         check_list.remove('ipsec_tunnel')
         check_list.append('ip_sec_tunnel_status')
+
+    if 'arp' in check_list:
+        check_list.remove('arp')
+        check_list.append('arp_entry_exists')
+
+    if (arp_entry := args.get('arp_entry_exists')) is not None and not is_ip_valid(arp_entry):
+        raise ValueError(
+            f"{arp_entry} is not a valid IPv4 address."
+        )
+
+    if 'ipsec_tunnel' in check_list:
+        check_list.remove('ipsec_tunnel')
+        check_list.append('ip_sec_tunnel_status')
+
+    # 'session_exist' already match upgrade assurance check type
 
     if 'arp' in check_list:
         check_list.remove('arp')

--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -267,12 +267,6 @@ def command_run_readiness_checks(panorama: Panorama):
         check_list.remove('dp_mp_clock_diff')
         check_list.append('planes_clock_sync')  # to match with upgrade assurance check type
 
-    # 'content_version' already match upgrade assurance check type
-
-    if 'dp_mp_clock_diff' in check_list:
-        check_list.remove('dp_mp_clock_diff')
-        check_list.append('planes_clock_sync')  # to match with upgrade assurance check type
-
     # this will set it to None if emptry string or not provided
     dp_mp_clock_diff = arg_to_number(args.get('dp_mp_clock_diff'), required=False)
     if args.get('dp_mp_clock_diff') is not None:
@@ -281,21 +275,6 @@ def command_run_readiness_checks(panorama: Panorama):
     if 'ipsec_tunnel' in check_list:
         check_list.remove('ipsec_tunnel')
         check_list.append('ip_sec_tunnel_status')
-
-    if 'arp' in check_list:
-        check_list.remove('arp')
-        check_list.append('arp_entry_exists')
-
-    if (arp_entry := args.get('arp_entry_exists')) is not None and not is_ip_valid(arp_entry):
-        raise ValueError(
-            f"{arp_entry} is not a valid IPv4 address."
-        )
-
-    if 'ipsec_tunnel' in check_list:
-        check_list.remove('ipsec_tunnel')
-        check_list.append('ip_sec_tunnel_status')
-
-    # 'session_exist' already match upgrade assurance check type
 
     if 'arp' in check_list:
         check_list.remove('arp')

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
@@ -1,6 +1,37 @@
 {
     "cacheVersn": 0,
-    "close": null,
+    "close": {
+        "sections": [
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "fieldId": "incident_closereason",
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_closenotes",
+                        "isVisible": true
+                    }
+                ],
+                "isVisible": true,
+                "name": "Basic Information",
+                "query": null,
+                "queryType": "",
+                "readOnly": false,
+                "type": ""
+            },
+            {
+                "description": "",
+                "isVisible": true,
+                "name": "Custom Fields",
+                "query": null,
+                "queryType": "",
+                "readOnly": false,
+                "type": ""
+            }
+        ]
+    },
     "definitionId": "",
     "description": "",
     "detached": false,
@@ -20,70 +51,7 @@
                     {
                         "displayType": "ROW",
                         "h": 2,
-                        "i": "caseinfoid-field-changed-caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                        "isVisible": true,
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "type",
-                                "height": 22,
-                                "id": "incident-type-field",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "owner",
-                                "height": 22,
-                                "id": "incident-owner-field",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "deviceupgradetimer",
-                                "height": 22,
-                                "id": "303b9300-5298-11ec-946c-1f59ee118fec",
-                                "index": 2,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "description",
-                                "height": 22,
-                                "id": "867ef420-394f-11ed-b057-f7592006a9bc",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "details",
-                                "height": 44,
-                                "id": "7efb4730-394f-11ed-b057-f7592006a9bc",
-                                "index": 4,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxH": null,
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Upgrade Details",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
                         "i": "caseinfoid-field-changed-caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
-                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -122,7 +90,6 @@
                         "h": 2,
                         "i": "caseinfoid-field-changed-caseinfoid-0f880450-16b4-11ed-afe0-bdd7fdc69d28",
                         "items": [],
-                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -181,7 +148,6 @@
                                 "startCol": 1
                             }
                         ],
-                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -199,10 +165,55 @@
                         "items": [
                             {
                                 "endCol": 2,
+                                "fieldId": "owner",
+                                "height": 53,
+                                "id": "incident-owner-field",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "type",
+                                "height": 53,
+                                "id": "incident-type-field",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "deviceupgradetimer",
+                                "height": 53,
+                                "id": "303b9300-5298-11ec-946c-1f59ee118fec",
+                                "index": 2,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "description",
+                                "height": 53,
+                                "id": "867ef420-394f-11ed-b057-f7592006a9bc",
+                                "index": 3,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "details",
+                                "height": 106,
+                                "id": "7efb4730-394f-11ed-b057-f7592006a9bc",
+                                "index": 4,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
                                 "fieldId": "releasenotes",
                                 "height": 53,
                                 "id": "aa317000-2b53-11ed-9983-57e28e0b15d1",
-                                "index": 0,
+                                "index": 5,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -212,7 +223,7 @@
                                 "fieldId": "panosnetworkoperationsupgradetargetversion",
                                 "height": 53,
                                 "id": "bea68c60-518c-11ec-8192-5b2617803d78",
-                                "index": 1,
+                                "index": 6,
                                 "listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
                                 "sectionItemType": "field",
                                 "startCol": 0
@@ -222,7 +233,7 @@
                                 "fieldId": "upgradepath",
                                 "height": 53,
                                 "id": "aad66c50-2913-11ed-beb7-e7d1c9c3493b",
-                                "index": 2,
+                                "index": 7,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -232,7 +243,7 @@
                                 "fieldId": "nextupgradeversion",
                                 "height": 53,
                                 "id": "b722ebf0-2913-11ed-beb7-e7d1c9c3493b",
-                                "index": 3,
+                                "index": 8,
                                 "listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
                                 "sectionItemType": "field",
                                 "startCol": 0
@@ -243,7 +254,7 @@
                                 "fieldId": "panosnetworkoperationsupgradepeerfirewall",
                                 "height": 53,
                                 "id": "5df9cdf0-179d-11ed-94d2-5958c8c003f6",
-                                "index": 4,
+                                "index": 9,
                                 "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
                                 "sectionItemType": "field",
                                 "startCol": 0
@@ -254,7 +265,7 @@
                                 "fieldId": "panosnetworkoperationstarget",
                                 "height": 53,
                                 "id": "3fd34c70-179d-11ed-94d2-5958c8c003f6",
-                                "index": 5,
+                                "index": 10,
                                 "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
                                 "sectionItemType": "field",
                                 "startCol": 0
@@ -264,7 +275,7 @@
                                 "fieldId": "completedupgradeversions",
                                 "height": 53,
                                 "id": "863d0bd0-297a-11ed-a5ba-67a09e091ca3",
-                                "index": 6,
+                                "index": 11,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             },
@@ -273,12 +284,11 @@
                                 "fieldId": "upgradeconfirmed",
                                 "height": 53,
                                 "id": "e74f5180-29e8-11ed-a245-61eb5379ed45",
-                                "index": 7,
+                                "index": 12,
                                 "sectionItemType": "field",
                                 "startCol": 0
                             }
                         ],
-                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -287,7 +297,7 @@
                         "w": 1,
                         "wrapLabels": true,
                         "x": 0,
-                        "y": 2
+                        "y": 0
                     },
                     {
                         "displayType": "ROW",
@@ -313,7 +323,6 @@
                                 "startCol": 0
                             }
                         ],
-                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -321,7 +330,7 @@
                         "static": false,
                         "w": 1,
                         "x": 1,
-                        "y": 4
+                        "y": 6
                     },
                     {
                         "displayType": "ROW",
@@ -345,7 +354,7 @@
                         "name": "Pre-Upgrade tests",
                         "static": false,
                         "w": 1,
-                        "x": 2,
+                        "x": 1,
                         "y": 4
                     },
                     {
@@ -394,7 +403,7 @@
                         "w": 1,
                         "wrapLabels": true,
                         "x": 1,
-                        "y": 6
+                        "y": 10
                     },
                     {
                         "displayType": "ROW",
@@ -418,12 +427,12 @@
                         "name": "HA Readiness Check (post failover)",
                         "static": false,
                         "w": 1,
-                        "x": 0,
-                        "y": 6
+                        "x": 1,
+                        "y": 8
                     },
                     {
                         "displayType": "CARD",
-                        "h": 2,
+                        "h": 4,
                         "hideName": false,
                         "i": "caseinfoid-491c8950-12cc-11ef-ab49-7fecada25a42",
                         "items": [
@@ -445,12 +454,12 @@
                         "name": "HA Upgrade Assurance Report (post Failover)",
                         "static": false,
                         "w": 1,
-                        "x": 0,
+                        "x": 2,
                         "y": 8
                     },
                     {
                         "displayType": "CARD",
-                        "h": 2,
+                        "h": 4,
                         "hideName": false,
                         "i": "caseinfoid-7c484e70-12ec-11ef-ab49-7fecada25a42",
                         "items": [
@@ -472,7 +481,182 @@
                         "w": 1,
                         "wrapLabels": false,
                         "x": 2,
-                        "y": 6
+                        "y": 4
+                    },
+                    {
+                        "displayType": "CARD",
+                        "h": 4,
+                        "i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+                        "isVisible": true,
+                        "items": [
+                            {
+                                "endCol": 2,
+                                "fieldId": "readinesschecklist",
+                                "height": 53,
+                                "id": "578676f0-ea40-11ed-939f-4f8b882605d4",
+                                "index": 0,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "minimumcontentversion",
+                                "filters": [
+                                    [
+                                        {
+                                            "ignoreCase": false,
+                                            "left": {
+                                                "isContext": true,
+                                                "value": {
+                                                    "simple": "readinesschecklist"
+                                                }
+                                            },
+                                            "operator": "containsGeneral",
+                                            "right": {
+                                                "isContext": false,
+                                                "value": {
+                                                    "simple": "content_version"
+                                                }
+                                            },
+                                            "type": "multiSelect"
+                                        }
+                                    ]
+                                ],
+                                "height": 53,
+                                "id": "79972af0-ea40-11ed-939f-4f8b882605d4",
+                                "index": 1,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "checksessionexists",
+                                "filters": [
+                                    [
+                                        {
+                                            "ignoreCase": false,
+                                            "left": {
+                                                "isContext": true,
+                                                "value": {
+                                                    "simple": "readinesschecklist"
+                                                }
+                                            },
+                                            "operator": "containsGeneral",
+                                            "right": {
+                                                "isContext": false,
+                                                "value": {
+                                                    "simple": "session_exist"
+                                                }
+                                            },
+                                            "type": "multiSelect"
+                                        }
+                                    ]
+                                ],
+                                "height": 53,
+                                "id": "694a9300-3c96-11ee-a0fd-e5af4a0a9390",
+                                "index": 2,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "checkarpentryexists",
+                                "filters": [
+                                    [
+                                        {
+                                            "ignoreCase": false,
+                                            "left": {
+                                                "isContext": true,
+                                                "value": {
+                                                    "simple": "readinesschecklist"
+                                                }
+                                            },
+                                            "operator": "containsGeneral",
+                                            "right": {
+                                                "isContext": false,
+                                                "value": {
+                                                    "simple": "arp"
+                                                }
+                                            },
+                                            "type": "multiSelect"
+                                        }
+                                    ]
+                                ],
+                                "height": 53,
+                                "id": "6b700b10-3c96-11ee-a0fd-e5af4a0a9390",
+                                "index": 3,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "ipsectunnel",
+                                "filters": [
+                                    [
+                                        {
+                                            "ignoreCase": false,
+                                            "left": {
+                                                "isContext": true,
+                                                "value": {
+                                                    "simple": "readinesschecklist"
+                                                }
+                                            },
+                                            "operator": "containsGeneral",
+                                            "right": {
+                                                "isContext": false,
+                                                "value": {
+                                                    "simple": "ipsec_tunnel"
+                                                }
+                                            },
+                                            "type": "multiSelect"
+                                        }
+                                    ]
+                                ],
+                                "height": 53,
+                                "id": "3aa90820-66d8-11ef-bcde-9775318adc09",
+                                "index": 4,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            },
+                            {
+                                "endCol": 2,
+                                "fieldId": "dpmpclockdiff",
+                                "filters": [
+                                    [
+                                        {
+                                            "ignoreCase": false,
+                                            "left": {
+                                                "isContext": true,
+                                                "value": {
+                                                    "simple": "readinesschecklist"
+                                                }
+                                            },
+                                            "operator": "containsGeneral",
+                                            "right": {
+                                                "isContext": false,
+                                                "value": {
+                                                    "simple": "dp_mp_clock_diff"
+                                                }
+                                            },
+                                            "type": "multiSelect"
+                                        }
+                                    ]
+                                ],
+                                "height": 53,
+                                "id": "102ff380-68fc-11ef-ac49-ed13fc730685",
+                                "index": 5,
+                                "sectionItemType": "field",
+                                "startCol": 0
+                            }
+                        ],
+                        "maxW": 3,
+                        "minH": 1,
+                        "moved": false,
+                        "name": "Assurance Test Configuration",
+                        "static": false,
+                        "w": 1,
+                        "x": 0,
+                        "y": 4
                     }
                 ],
                 "type": "custom"
@@ -521,11 +705,11 @@
                         "isVisible": true
                     },
                     {
-                        "fieldId": "incident_panosnetworkoperationsupgradetargetdevice",
+                        "fieldId": "incident_panosnetworkoperationsupgradetargetversion",
                         "isVisible": true
                     },
                     {
-                        "fieldId": "incident_panosnetworkoperationsupgradetargetversion",
+                        "fieldId": "incident_panosnetworkoperationstarget",
                         "isVisible": true
                     },
                     {
@@ -535,6 +719,136 @@
                 ],
                 "isVisible": true,
                 "name": "Basic Information",
+                "query": null,
+                "queryType": "",
+                "readOnly": false,
+                "type": ""
+            },
+            {
+                "description": "",
+                "fields": [
+                    {
+                        "fieldId": "incident_readinesschecklist",
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_minimumcontentversion",
+                        "filters": [
+                            [
+                                {
+                                    "left": {
+                                        "isContext": true,
+                                        "value": {
+                                            "simple": "readinesschecklist"
+                                        }
+                                    },
+                                    "operator": "containsGeneral",
+                                    "right": {
+                                        "value": {
+                                            "simple": "content_version"
+                                        }
+                                    },
+                                    "type": "multiSelect"
+                                }
+                            ]
+                        ],
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_checkarpentryexists",
+                        "filters": [
+                            [
+                                {
+                                    "left": {
+                                        "isContext": true,
+                                        "value": {
+                                            "simple": "readinesschecklist"
+                                        }
+                                    },
+                                    "operator": "containsGeneral",
+                                    "right": {
+                                        "value": {
+                                            "simple": "arp"
+                                        }
+                                    },
+                                    "type": "multiSelect"
+                                }
+                            ]
+                        ],
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_checksessionexists",
+                        "filters": [
+                            [
+                                {
+                                    "left": {
+                                        "isContext": true,
+                                        "value": {
+                                            "simple": "readinesschecklist"
+                                        }
+                                    },
+                                    "operator": "containsGeneral",
+                                    "right": {
+                                        "value": {
+                                            "simple": "session_exist"
+                                        }
+                                    },
+                                    "type": "multiSelect"
+                                }
+                            ]
+                        ],
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_ipsectunnel",
+                        "filters": [
+                            [
+                                {
+                                    "left": {
+                                        "isContext": true,
+                                        "value": {
+                                            "simple": "readinesschecklist"
+                                        }
+                                    },
+                                    "operator": "containsGeneral",
+                                    "right": {
+                                        "value": {
+                                            "simple": "ipsec_tunnel"
+                                        }
+                                    },
+                                    "type": "multiSelect"
+                                }
+                            ]
+                        ],
+                        "isVisible": true
+                    },
+                    {
+                        "fieldId": "incident_dpmpclockdiff",
+                        "filters": [
+                            [
+                                {
+                                    "left": {
+                                        "isContext": true,
+                                        "value": {
+                                            "simple": "readinesschecklist"
+                                        }
+                                    },
+                                    "operator": "containsGeneral",
+                                    "right": {
+                                        "value": {
+                                            "simple": "dp_mp_clock_diff"
+                                        }
+                                    },
+                                    "type": "multiSelect"
+                                }
+                            ]
+                        ],
+                        "isVisible": true
+                    }
+                ],
+                "isVisible": true,
+                "name": "Advanced Test Configuration",
                 "query": null,
                 "queryType": "",
                 "readOnly": false,

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
@@ -52,6 +52,7 @@
                         "displayType": "ROW",
                         "h": 2,
                         "i": "caseinfoid-field-changed-caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -90,6 +91,7 @@
                         "h": 2,
                         "i": "caseinfoid-field-changed-caseinfoid-0f880450-16b4-11ed-afe0-bdd7fdc69d28",
                         "items": [],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,
@@ -148,6 +150,7 @@
                                 "startCol": 1
                             }
                         ],
+                        "maxH": null,
                         "maxW": 3,
                         "minH": 1,
                         "moved": false,

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Device_Upgrade.json
@@ -1,878 +1,875 @@
 {
-    "cacheVersn": 0,
-    "close": {
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_closereason",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_closenotes",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "isVisible": true,
-                "name": "Custom Fields",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            }
-        ]
-    },
-    "definitionId": "",
-    "description": "",
-    "detached": false,
-    "details": null,
-    "detailsV2": {
-        "TypeName": "",
-        "tabs": [
-            {
-                "id": "summary",
-                "name": "Legacy Summary",
-                "type": "summary"
-            },
-            {
-                "id": "caseinfoid",
-                "name": "Upgrade Details",
-                "sections": [
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "i": "caseinfoid-field-changed-caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
-                        "maxH": null,
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Work Plan",
-                        "static": false,
-                        "type": "workplan",
-                        "w": 1,
-                        "x": 1,
-                        "y": 0
-                    },
-                    {
-                        "columns": [
-                            {
-                                "displayed": true,
-                                "isDefault": true,
-                                "key": "value",
-                                "width": 300
-                            },
-                            {
-                                "displayed": true,
-                                "key": "Hostname",
-                                "width": 200
-                            },
-                            {
-                                "displayed": true,
-                                "key": "Software Version",
-                                "width": 200
-                            },
-                            {
-                                "displayed": true,
-                                "key": "Device Tags",
-                                "width": 200
-                            }
-                        ],
-                        "description": "",
-                        "h": 2,
-                        "i": "caseinfoid-field-changed-caseinfoid-0f880450-16b4-11ed-afe0-bdd7fdc69d28",
-                        "items": [],
-                        "maxH": null,
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Target Device",
-                        "query": "type:\"Panorama Device\" or type:\"Network Device\"",
-                        "queryType": "input",
-                        "static": false,
-                        "type": "indicators",
-                        "w": 2,
-                        "x": 1,
-                        "y": 2
-                    },
-                    {
-                        "description": "",
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-field-changed-caseinfoid-46eb4140-1787-11ed-8d72-0d6d26ea3938",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "preupgradesnapshotfile",
-                                "height": 22,
-                                "id": "6abe3eb0-1787-11ed-8d72-0d6d26ea3938",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "assurancetestresult",
-                                "height": 22,
-                                "id": "f0736990-eb2b-11ed-a48e-3b53abdb4307",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 1,
-                                "fieldId": "firstsnapshot",
-                                "height": 53,
-                                "id": "f63d3180-eb2b-11ed-a48e-3b53abdb4307",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "secondsnapshot",
-                                "height": 53,
-                                "id": "f9c51fc0-eb2b-11ed-a48e-3b53abdb4307",
-                                "index": 1,
-                                "listId": "caseinfoid-field-changed-caseinfoid-46eb4140-1787-11ed-8d72-0d6d26ea3938",
-                                "sectionItemType": "field",
-                                "startCol": 1
-                            }
-                        ],
-                        "maxH": null,
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Assurance Tests",
-                        "static": false,
-                        "w": 1,
-                        "x": 2,
-                        "y": 0
-                    },
-                    {
-                        "displayType": "CARD",
-                        "h": 4,
-                        "hideName": false,
-                        "i": "caseinfoid-field-changed-caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "owner",
-                                "height": 53,
-                                "id": "incident-owner-field",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "type",
-                                "height": 53,
-                                "id": "incident-type-field",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "deviceupgradetimer",
-                                "height": 53,
-                                "id": "303b9300-5298-11ec-946c-1f59ee118fec",
-                                "index": 2,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "description",
-                                "height": 53,
-                                "id": "867ef420-394f-11ed-b057-f7592006a9bc",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "details",
-                                "height": 106,
-                                "id": "7efb4730-394f-11ed-b057-f7592006a9bc",
-                                "index": 4,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "releasenotes",
-                                "height": 53,
-                                "id": "aa317000-2b53-11ed-9983-57e28e0b15d1",
-                                "index": 5,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "panosnetworkoperationsupgradetargetversion",
-                                "height": 53,
-                                "id": "bea68c60-518c-11ec-8192-5b2617803d78",
-                                "index": 6,
-                                "listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "upgradepath",
-                                "height": 53,
-                                "id": "aad66c50-2913-11ed-beb7-e7d1c9c3493b",
-                                "index": 7,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "nextupgradeversion",
-                                "height": 53,
-                                "id": "b722ebf0-2913-11ed-beb7-e7d1c9c3493b",
-                                "index": 8,
-                                "listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "panosnetworkoperationsupgradepeerfirewall",
-                                "height": 53,
-                                "id": "5df9cdf0-179d-11ed-94d2-5958c8c003f6",
-                                "index": 9,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "panosnetworkoperationstarget",
-                                "height": 53,
-                                "id": "3fd34c70-179d-11ed-94d2-5958c8c003f6",
-                                "index": 10,
-                                "listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "completedupgradeversions",
-                                "height": 53,
-                                "id": "863d0bd0-297a-11ed-a5ba-67a09e091ca3",
-                                "index": 11,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "upgradeconfirmed",
-                                "height": 53,
-                                "id": "e74f5180-29e8-11ed-a245-61eb5379ed45",
-                                "index": 12,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Upgrade Details",
-                        "static": false,
-                        "w": 1,
-                        "wrapLabels": true,
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-field-changed-caseinfoid-2b196e40-2b48-11ed-9983-57e28e0b15d1",
-                        "items": [
-                            {
-                                "args": {
-                                    "name": {
-                                        "simple": "PAN-OS Network Operations - Device Upgrade"
-                                    }
-                                },
-                                "buttonClass": "warning",
-                                "endCol": 2,
-                                "fieldId": "",
-                                "height": 44,
-                                "id": "3134b190-2b48-11ed-9983-57e28e0b15d1",
-                                "index": 0,
-                                "name": "Restart Upgrade",
-                                "scriptId": "Builtin|||setPlaybook",
-                                "sectionItemType": "button",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Actions",
-                        "static": false,
-                        "w": 1,
-                        "x": 1,
-                        "y": 6
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-64ce22c0-eb2d-11ed-a48e-3b53abdb4307",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "readinesscheckresult",
-                                "height": 22,
-                                "id": "70f4a3d0-eb2d-11ed-a48e-3b53abdb4307",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Pre-Upgrade tests",
-                        "static": false,
-                        "w": 1,
-                        "x": 1,
-                        "y": 4
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "haassurancetestresult",
-                                "height": 26,
-                                "id": "10e9bf30-122c-11ef-aed6-958b0929b884",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 1,
-                                "fieldId": "firstsnapshot",
-                                "height": 53,
-                                "id": "323686f0-122c-11ef-aed6-958b0929b884",
-                                "index": 1,
-                                "listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "hasnapshot",
-                                "height": 53,
-                                "id": "4412f9d0-122c-11ef-aed6-958b0929b884",
-                                "index": 1,
-                                "listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
-                                "sectionItemType": "field",
-                                "startCol": 1
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "HA Assurance Tests (post failover)",
-                        "static": false,
-                        "w": 1,
-                        "wrapLabels": true,
-                        "x": 1,
-                        "y": 10
-                    },
-                    {
-                        "displayType": "ROW",
-                        "h": 2,
-                        "hideName": false,
-                        "i": "caseinfoid-6bbfd611-122c-11ef-aed6-958b0929b884",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "hareadinesscheckresult",
-                                "height": 26,
-                                "id": "80030fc0-122c-11ef-aed6-958b0929b884",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "HA Readiness Check (post failover)",
-                        "static": false,
-                        "w": 1,
-                        "x": 1,
-                        "y": 8
-                    },
-                    {
-                        "displayType": "CARD",
-                        "h": 4,
-                        "hideName": false,
-                        "i": "caseinfoid-491c8950-12cc-11ef-ab49-7fecada25a42",
-                        "items": [
-                            {
-                                "dropEffect": "move",
-                                "endCol": 2,
-                                "fieldId": "haupgradeassurancereport",
-                                "height": 106,
-                                "id": "286148e0-122c-11ef-aed6-958b0929b884",
-                                "index": 0,
-                                "listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "HA Upgrade Assurance Report (post Failover)",
-                        "static": false,
-                        "w": 1,
-                        "x": 2,
-                        "y": 8
-                    },
-                    {
-                        "displayType": "CARD",
-                        "h": 4,
-                        "hideName": false,
-                        "i": "caseinfoid-7c484e70-12ec-11ef-ab49-7fecada25a42",
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "upgradeassurancereport",
-                                "height": 26,
-                                "id": "b52a12f0-12ec-11ef-ab49-7fecada25a42",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Final Upgrade Assurance Report",
-                        "static": false,
-                        "w": 1,
-                        "wrapLabels": false,
-                        "x": 2,
-                        "y": 4
-                    },
-                    {
-                        "displayType": "CARD",
-                        "h": 4,
-                        "i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
-                        "isVisible": true,
-                        "items": [
-                            {
-                                "endCol": 2,
-                                "fieldId": "readinesschecklist",
-                                "height": 53,
-                                "id": "578676f0-ea40-11ed-939f-4f8b882605d4",
-                                "index": 0,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "minimumcontentversion",
-                                "filters": [
-                                    [
-                                        {
-                                            "ignoreCase": false,
-                                            "left": {
-                                                "isContext": true,
-                                                "value": {
-                                                    "simple": "readinesschecklist"
-                                                }
-                                            },
-                                            "operator": "containsGeneral",
-                                            "right": {
-                                                "isContext": false,
-                                                "value": {
-                                                    "simple": "content_version"
-                                                }
-                                            },
-                                            "type": "multiSelect"
-                                        }
-                                    ]
-                                ],
-                                "height": 53,
-                                "id": "79972af0-ea40-11ed-939f-4f8b882605d4",
-                                "index": 1,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "checksessionexists",
-                                "filters": [
-                                    [
-                                        {
-                                            "ignoreCase": false,
-                                            "left": {
-                                                "isContext": true,
-                                                "value": {
-                                                    "simple": "readinesschecklist"
-                                                }
-                                            },
-                                            "operator": "containsGeneral",
-                                            "right": {
-                                                "isContext": false,
-                                                "value": {
-                                                    "simple": "session_exist"
-                                                }
-                                            },
-                                            "type": "multiSelect"
-                                        }
-                                    ]
-                                ],
-                                "height": 53,
-                                "id": "694a9300-3c96-11ee-a0fd-e5af4a0a9390",
-                                "index": 2,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "checkarpentryexists",
-                                "filters": [
-                                    [
-                                        {
-                                            "ignoreCase": false,
-                                            "left": {
-                                                "isContext": true,
-                                                "value": {
-                                                    "simple": "readinesschecklist"
-                                                }
-                                            },
-                                            "operator": "containsGeneral",
-                                            "right": {
-                                                "isContext": false,
-                                                "value": {
-                                                    "simple": "arp"
-                                                }
-                                            },
-                                            "type": "multiSelect"
-                                        }
-                                    ]
-                                ],
-                                "height": 53,
-                                "id": "6b700b10-3c96-11ee-a0fd-e5af4a0a9390",
-                                "index": 3,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "ipsectunnel",
-                                "filters": [
-                                    [
-                                        {
-                                            "ignoreCase": false,
-                                            "left": {
-                                                "isContext": true,
-                                                "value": {
-                                                    "simple": "readinesschecklist"
-                                                }
-                                            },
-                                            "operator": "containsGeneral",
-                                            "right": {
-                                                "isContext": false,
-                                                "value": {
-                                                    "simple": "ipsec_tunnel"
-                                                }
-                                            },
-                                            "type": "multiSelect"
-                                        }
-                                    ]
-                                ],
-                                "height": 53,
-                                "id": "3aa90820-66d8-11ef-bcde-9775318adc09",
-                                "index": 4,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            },
-                            {
-                                "endCol": 2,
-                                "fieldId": "dpmpclockdiff",
-                                "filters": [
-                                    [
-                                        {
-                                            "ignoreCase": false,
-                                            "left": {
-                                                "isContext": true,
-                                                "value": {
-                                                    "simple": "readinesschecklist"
-                                                }
-                                            },
-                                            "operator": "containsGeneral",
-                                            "right": {
-                                                "isContext": false,
-                                                "value": {
-                                                    "simple": "dp_mp_clock_diff"
-                                                }
-                                            },
-                                            "type": "multiSelect"
-                                        }
-                                    ]
-                                ],
-                                "height": 53,
-                                "id": "102ff380-68fc-11ef-ac49-ed13fc730685",
-                                "index": 5,
-                                "sectionItemType": "field",
-                                "startCol": 0
-                            }
-                        ],
-                        "maxW": 3,
-                        "minH": 1,
-                        "moved": false,
-                        "name": "Assurance Test Configuration",
-                        "static": false,
-                        "w": 1,
-                        "x": 0,
-                        "y": 4
-                    }
-                ],
-                "type": "custom"
-            },
-            {
-                "id": "warRoom",
-                "name": "War Room",
-                "type": "warRoom"
-            },
-            {
-                "id": "workPlan",
-                "name": "Work Plan",
-                "type": "workPlan"
-            },
-            {
-                "hidden": true,
-                "id": "evidenceBoard",
-                "name": "Evidence Board",
-                "type": "evidenceBoard"
-            },
-            {
-                "hidden": true,
-                "id": "relatedIncidents",
-                "name": "Related Incidents",
-                "type": "relatedIncidents"
-            },
-            {
-                "hidden": true,
-                "id": "canvas",
-                "name": "Canvas",
-                "type": "canvas"
-            }
-        ]
-    },
-    "edit": {
-        "sections": [
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_name",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_type",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_panosnetworkoperationsupgradetargetversion",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_panosnetworkoperationstarget",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_panosnetworkoperationspanoramainstance",
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Basic Information",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            },
-            {
-                "description": "",
-                "fields": [
-                    {
-                        "fieldId": "incident_readinesschecklist",
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_minimumcontentversion",
-                        "filters": [
-                            [
-                                {
-                                    "left": {
-                                        "isContext": true,
-                                        "value": {
-                                            "simple": "readinesschecklist"
-                                        }
-                                    },
-                                    "operator": "containsGeneral",
-                                    "right": {
-                                        "value": {
-                                            "simple": "content_version"
-                                        }
-                                    },
-                                    "type": "multiSelect"
-                                }
-                            ]
-                        ],
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_checkarpentryexists",
-                        "filters": [
-                            [
-                                {
-                                    "left": {
-                                        "isContext": true,
-                                        "value": {
-                                            "simple": "readinesschecklist"
-                                        }
-                                    },
-                                    "operator": "containsGeneral",
-                                    "right": {
-                                        "value": {
-                                            "simple": "arp"
-                                        }
-                                    },
-                                    "type": "multiSelect"
-                                }
-                            ]
-                        ],
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_checksessionexists",
-                        "filters": [
-                            [
-                                {
-                                    "left": {
-                                        "isContext": true,
-                                        "value": {
-                                            "simple": "readinesschecklist"
-                                        }
-                                    },
-                                    "operator": "containsGeneral",
-                                    "right": {
-                                        "value": {
-                                            "simple": "session_exist"
-                                        }
-                                    },
-                                    "type": "multiSelect"
-                                }
-                            ]
-                        ],
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_ipsectunnel",
-                        "filters": [
-                            [
-                                {
-                                    "left": {
-                                        "isContext": true,
-                                        "value": {
-                                            "simple": "readinesschecklist"
-                                        }
-                                    },
-                                    "operator": "containsGeneral",
-                                    "right": {
-                                        "value": {
-                                            "simple": "ipsec_tunnel"
-                                        }
-                                    },
-                                    "type": "multiSelect"
-                                }
-                            ]
-                        ],
-                        "isVisible": true
-                    },
-                    {
-                        "fieldId": "incident_dpmpclockdiff",
-                        "filters": [
-                            [
-                                {
-                                    "left": {
-                                        "isContext": true,
-                                        "value": {
-                                            "simple": "readinesschecklist"
-                                        }
-                                    },
-                                    "operator": "containsGeneral",
-                                    "right": {
-                                        "value": {
-                                            "simple": "dp_mp_clock_diff"
-                                        }
-                                    },
-                                    "type": "multiSelect"
-                                }
-                            ]
-                        ],
-                        "isVisible": true
-                    }
-                ],
-                "isVisible": true,
-                "name": "Advanced Test Configuration",
-                "query": null,
-                "queryType": "",
-                "readOnly": false,
-                "type": ""
-            }
-        ]
-    },
-    "fromServerVersion": "0.0.0",
-    "group": "incident",
-    "id": "PAN-OS Network Operations - Device Upgrade",
-    "indicatorsDetails": null,
-    "indicatorsQuickView": null,
-    "itemVersion": "",
-    "locked": false,
-    "mobile": null,
-    "name": "PAN-OS Network Operations - Device Upgrade",
-    "packID": "",
-    "packName": "",
-    "quickView": null,
-    "quickViewV2": null,
-    "system": false,
-    "toServerVersion": "99.99.99",
-    "version": -1
+	"cacheVersn": 0,
+	"close": {
+		"sections": [
+			{
+				"description": "",
+				"fields": [
+					{
+						"fieldId": "incident_closereason",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_closenotes",
+						"isVisible": true
+					}
+				],
+				"isVisible": true,
+				"name": "Basic Information",
+				"query": null,
+				"queryType": "",
+				"readOnly": false,
+				"type": ""
+			},
+			{
+				"description": "",
+				"isVisible": true,
+				"name": "Custom Fields",
+				"query": null,
+				"queryType": "",
+				"readOnly": false,
+				"type": ""
+			}
+		]
+	},
+	"definitionId": "",
+	"description": "",
+	"detached": false,
+	"details": null,
+	"detailsV2": {
+		"TypeName": "",
+		"tabs": [
+			{
+				"id": "summary",
+				"name": "Legacy Summary",
+				"type": "summary"
+			},
+			{
+				"id": "caseinfoid",
+				"name": "Upgrade Details",
+				"sections": [
+					{
+						"displayType": "ROW",
+						"h": 2,
+						"i": "caseinfoid-field-changed-caseinfoid-6aabad20-98b1-11e9-97d7-ed26ef9e46c8",
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Work Plan",
+						"static": false,
+						"type": "workplan",
+						"w": 1,
+						"x": 1,
+						"y": 0
+					},
+					{
+						"columns": [
+							{
+								"displayed": true,
+								"isDefault": true,
+								"key": "value",
+								"width": 300
+							},
+							{
+								"displayed": true,
+								"key": "Hostname",
+								"width": 200
+							},
+							{
+								"displayed": true,
+								"key": "Software Version",
+								"width": 200
+							},
+							{
+								"displayed": true,
+								"key": "Device Tags",
+								"width": 200
+							}
+						],
+						"description": "",
+						"h": 2,
+						"i": "caseinfoid-field-changed-caseinfoid-0f880450-16b4-11ed-afe0-bdd7fdc69d28",
+						"items": [],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Target Device",
+						"query": "type:\"Panorama Device\" or type:\"Network Device\"",
+						"queryType": "input",
+						"static": false,
+						"type": "indicators",
+						"w": 2,
+						"x": 1,
+						"y": 2
+					},
+					{
+						"description": "",
+						"displayType": "ROW",
+						"h": 2,
+						"hideName": false,
+						"i": "caseinfoid-field-changed-caseinfoid-46eb4140-1787-11ed-8d72-0d6d26ea3938",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "preupgradesnapshotfile",
+								"height": 22,
+								"id": "6abe3eb0-1787-11ed-8d72-0d6d26ea3938",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "assurancetestresult",
+								"height": 22,
+								"id": "f0736990-eb2b-11ed-a48e-3b53abdb4307",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 1,
+								"fieldId": "firstsnapshot",
+								"height": 53,
+								"id": "f63d3180-eb2b-11ed-a48e-3b53abdb4307",
+								"index": 1,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "secondsnapshot",
+								"height": 53,
+								"id": "f9c51fc0-eb2b-11ed-a48e-3b53abdb4307",
+								"index": 1,
+								"listId": "caseinfoid-field-changed-caseinfoid-46eb4140-1787-11ed-8d72-0d6d26ea3938",
+								"sectionItemType": "field",
+								"startCol": 1
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Assurance Tests",
+						"static": false,
+						"w": 1,
+						"x": 2,
+						"y": 0
+					},
+					{
+						"displayType": "CARD",
+						"h": 4,
+						"hideName": false,
+						"i": "caseinfoid-field-changed-caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "owner",
+								"height": 53,
+								"id": "incident-owner-field",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "type",
+								"height": 53,
+								"id": "incident-type-field",
+								"index": 1,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "deviceupgradetimer",
+								"height": 53,
+								"id": "303b9300-5298-11ec-946c-1f59ee118fec",
+								"index": 2,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "description",
+								"height": 53,
+								"id": "867ef420-394f-11ed-b057-f7592006a9bc",
+								"index": 3,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "details",
+								"height": 106,
+								"id": "7efb4730-394f-11ed-b057-f7592006a9bc",
+								"index": 4,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "releasenotes",
+								"height": 53,
+								"id": "aa317000-2b53-11ed-9983-57e28e0b15d1",
+								"index": 5,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "panosnetworkoperationsupgradetargetversion",
+								"height": 53,
+								"id": "bea68c60-518c-11ec-8192-5b2617803d78",
+								"index": 6,
+								"listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "upgradepath",
+								"height": 53,
+								"id": "aad66c50-2913-11ed-beb7-e7d1c9c3493b",
+								"index": 7,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "nextupgradeversion",
+								"height": 53,
+								"id": "b722ebf0-2913-11ed-beb7-e7d1c9c3493b",
+								"index": 8,
+								"listId": "caseinfoid-94a59370-2913-11ed-beb7-e7d1c9c3493b",
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "panosnetworkoperationsupgradepeerfirewall",
+								"height": 53,
+								"id": "5df9cdf0-179d-11ed-94d2-5958c8c003f6",
+								"index": 9,
+								"listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "panosnetworkoperationstarget",
+								"height": 53,
+								"id": "3fd34c70-179d-11ed-94d2-5958c8c003f6",
+								"index": 10,
+								"listId": "caseinfoid-fce71720-98b0-11e9-97d7-ed26ef9e46c8",
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "completedupgradeversions",
+								"height": 53,
+								"id": "863d0bd0-297a-11ed-a5ba-67a09e091ca3",
+								"index": 11,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "upgradeconfirmed",
+								"height": 53,
+								"id": "e74f5180-29e8-11ed-a245-61eb5379ed45",
+								"index": 12,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Upgrade Details",
+						"static": false,
+						"w": 1,
+						"wrapLabels": true,
+						"x": 0,
+						"y": 0
+					},
+					{
+						"displayType": "ROW",
+						"h": 2,
+						"hideName": false,
+						"i": "caseinfoid-field-changed-caseinfoid-2b196e40-2b48-11ed-9983-57e28e0b15d1",
+						"items": [
+							{
+								"args": {
+									"name": {
+										"simple": "PAN-OS Network Operations - Device Upgrade"
+									}
+								},
+								"buttonClass": "warning",
+								"endCol": 2,
+								"fieldId": "",
+								"height": 44,
+								"id": "3134b190-2b48-11ed-9983-57e28e0b15d1",
+								"index": 0,
+								"name": "Restart Upgrade",
+								"scriptId": "Builtin|||setPlaybook",
+								"sectionItemType": "button",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Actions",
+						"static": false,
+						"w": 1,
+						"x": 1,
+						"y": 6
+					},
+					{
+						"displayType": "ROW",
+						"h": 2,
+						"hideName": false,
+						"i": "caseinfoid-64ce22c0-eb2d-11ed-a48e-3b53abdb4307",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "readinesscheckresult",
+								"height": 22,
+								"id": "70f4a3d0-eb2d-11ed-a48e-3b53abdb4307",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Pre-Upgrade tests",
+						"static": false,
+						"w": 1,
+						"x": 1,
+						"y": 4
+					},
+					{
+						"displayType": "ROW",
+						"h": 4,
+						"hideName": false,
+						"i": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "haassurancetestresult",
+								"height": 26,
+								"id": "10e9bf30-122c-11ef-aed6-958b0929b884",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 1,
+								"fieldId": "firstsnapshot",
+								"height": 53,
+								"id": "323686f0-122c-11ef-aed6-958b0929b884",
+								"index": 1,
+								"listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "hasnapshot",
+								"height": 53,
+								"id": "4412f9d0-122c-11ef-aed6-958b0929b884",
+								"index": 1,
+								"listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
+								"sectionItemType": "field",
+								"startCol": 1
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "HA Assurance Tests (post failover)",
+						"static": false,
+						"w": 1,
+						"wrapLabels": true,
+						"x": 1,
+						"y": 8
+					},
+					{
+						"displayType": "ROW",
+						"h": 4,
+						"hideName": false,
+						"i": "caseinfoid-6bbfd611-122c-11ef-aed6-958b0929b884",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "hareadinesscheckresult",
+								"height": 26,
+								"id": "80030fc0-122c-11ef-aed6-958b0929b884",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "HA Readiness Check (post failover)",
+						"static": false,
+						"w": 1,
+						"x": 0,
+						"y": 8
+					},
+					{
+						"displayType": "CARD",
+						"h": 4,
+						"hideName": false,
+						"i": "caseinfoid-491c8950-12cc-11ef-ab49-7fecada25a42",
+						"items": [
+							{
+								"dropEffect": "move",
+								"endCol": 2,
+								"fieldId": "haupgradeassurancereport",
+								"height": 106,
+								"id": "286148e0-122c-11ef-aed6-958b0929b884",
+								"index": 0,
+								"listId": "caseinfoid-ef0c0210-122b-11ef-aed6-958b0929b884",
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "HA Upgrade Assurance Report (post Failover)",
+						"static": false,
+						"w": 1,
+						"x": 2,
+						"y": 8
+					},
+					{
+						"displayType": "CARD",
+						"h": 4,
+						"hideName": false,
+						"i": "caseinfoid-7c484e70-12ec-11ef-ab49-7fecada25a42",
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "upgradeassurancereport",
+								"height": 26,
+								"id": "b52a12f0-12ec-11ef-ab49-7fecada25a42",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Final Upgrade Assurance Report",
+						"static": false,
+						"w": 1,
+						"wrapLabels": false,
+						"x": 2,
+						"y": 4
+					},
+					{
+						"displayType": "CARD",
+						"h": 4,
+						"i": "caseinfoid-e54b1770-a0b1-11e9-b27f-13ae1773d289",
+						"isVisible": true,
+						"items": [
+							{
+								"endCol": 2,
+								"fieldId": "readinesschecklist",
+								"height": 53,
+								"id": "578676f0-ea40-11ed-939f-4f8b882605d4",
+								"index": 0,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "minimumcontentversion",
+								"filters": [
+									[
+										{
+											"ignoreCase": false,
+											"left": {
+												"isContext": true,
+												"value": {
+													"simple": "readinesschecklist"
+												}
+											},
+											"operator": "containsGeneral",
+											"right": {
+												"isContext": false,
+												"value": {
+													"simple": "content_version"
+												}
+											},
+											"type": "multiSelect"
+										}
+									]
+								],
+								"height": 53,
+								"id": "79972af0-ea40-11ed-939f-4f8b882605d4",
+								"index": 1,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "checksessionexists",
+								"filters": [
+									[
+										{
+											"ignoreCase": false,
+											"left": {
+												"isContext": true,
+												"value": {
+													"simple": "readinesschecklist"
+												}
+											},
+											"operator": "containsGeneral",
+											"right": {
+												"isContext": false,
+												"value": {
+													"simple": "session_exist"
+												}
+											},
+											"type": "multiSelect"
+										}
+									]
+								],
+								"height": 53,
+								"id": "694a9300-3c96-11ee-a0fd-e5af4a0a9390",
+								"index": 2,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "checkarpentryexists",
+								"filters": [
+									[
+										{
+											"ignoreCase": false,
+											"left": {
+												"isContext": true,
+												"value": {
+													"simple": "readinesschecklist"
+												}
+											},
+											"operator": "containsGeneral",
+											"right": {
+												"isContext": false,
+												"value": {
+													"simple": "arp"
+												}
+											},
+											"type": "multiSelect"
+										}
+									]
+								],
+								"height": 53,
+								"id": "6b700b10-3c96-11ee-a0fd-e5af4a0a9390",
+								"index": 3,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "ipsectunnel",
+								"filters": [
+									[
+										{
+											"ignoreCase": false,
+											"left": {
+												"isContext": true,
+												"value": {
+													"simple": "readinesschecklist"
+												}
+											},
+											"operator": "containsGeneral",
+											"right": {
+												"isContext": false,
+												"value": {
+													"simple": "ipsec_tunnel"
+												}
+											},
+											"type": "multiSelect"
+										}
+									]
+								],
+								"height": 53,
+								"id": "3aa90820-66d8-11ef-bcde-9775318adc09",
+								"index": 4,
+								"sectionItemType": "field",
+								"startCol": 0
+							},
+							{
+								"endCol": 2,
+								"fieldId": "dpmpclockdiff",
+								"filters": [
+									[
+										{
+											"ignoreCase": false,
+											"left": {
+												"isContext": true,
+												"value": {
+													"simple": "readinesschecklist"
+												}
+											},
+											"operator": "containsGeneral",
+											"right": {
+												"isContext": false,
+												"value": {
+													"simple": "dp_mp_clock_diff"
+												}
+											},
+											"type": "multiSelect"
+										}
+									]
+								],
+								"height": 53,
+								"id": "102ff380-68fc-11ef-ac49-ed13fc730685",
+								"index": 5,
+								"sectionItemType": "field",
+								"startCol": 0
+							}
+						],
+						"maxW": 3,
+						"minH": 1,
+						"moved": false,
+						"name": "Assurance Test Configuration",
+						"static": false,
+						"w": 1,
+						"x": 0,
+						"y": 4
+					}
+				],
+				"type": "custom"
+			},
+			{
+				"id": "warRoom",
+				"name": "War Room",
+				"type": "warRoom"
+			},
+			{
+				"id": "workPlan",
+				"name": "Work Plan",
+				"type": "workPlan"
+			},
+			{
+				"hidden": true,
+				"id": "evidenceBoard",
+				"name": "Evidence Board",
+				"type": "evidenceBoard"
+			},
+			{
+				"hidden": true,
+				"id": "relatedIncidents",
+				"name": "Related Incidents",
+				"type": "relatedIncidents"
+			},
+			{
+				"hidden": true,
+				"id": "canvas",
+				"name": "Canvas",
+				"type": "canvas"
+			}
+		]
+	},
+	"edit": {
+		"sections": [
+			{
+				"description": "",
+				"fields": [
+					{
+						"fieldId": "incident_name",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_type",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_panosnetworkoperationsupgradetargetversion",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_panosnetworkoperationstarget",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_panosnetworkoperationspanoramainstance",
+						"isVisible": true
+					}
+				],
+				"isVisible": true,
+				"name": "Basic Information",
+				"query": null,
+				"queryType": "",
+				"readOnly": false,
+				"type": ""
+			},
+			{
+				"description": "",
+				"fields": [
+					{
+						"fieldId": "incident_readinesschecklist",
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_minimumcontentversion",
+						"filters": [
+							[
+								{
+									"left": {
+										"isContext": true,
+										"value": {
+											"simple": "readinesschecklist"
+										}
+									},
+									"operator": "containsGeneral",
+									"right": {
+										"value": {
+											"simple": "content_version"
+										}
+									},
+									"type": "multiSelect"
+								}
+							]
+						],
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_checkarpentryexists",
+						"filters": [
+							[
+								{
+									"left": {
+										"isContext": true,
+										"value": {
+											"simple": "readinesschecklist"
+										}
+									},
+									"operator": "containsGeneral",
+									"right": {
+										"value": {
+											"simple": "arp"
+										}
+									},
+									"type": "multiSelect"
+								}
+							]
+						],
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_checksessionexists",
+						"filters": [
+							[
+								{
+									"left": {
+										"isContext": true,
+										"value": {
+											"simple": "readinesschecklist"
+										}
+									},
+									"operator": "containsGeneral",
+									"right": {
+										"value": {
+											"simple": "session_exist"
+										}
+									},
+									"type": "multiSelect"
+								}
+							]
+						],
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_ipsectunnel",
+						"filters": [
+							[
+								{
+									"left": {
+										"isContext": true,
+										"value": {
+											"simple": "readinesschecklist"
+										}
+									},
+									"operator": "containsGeneral",
+									"right": {
+										"value": {
+											"simple": "ipsec_tunnel"
+										}
+									},
+									"type": "multiSelect"
+								}
+							]
+						],
+						"isVisible": true
+					},
+					{
+						"fieldId": "incident_dpmpclockdiff",
+						"filters": [
+							[
+								{
+									"left": {
+										"isContext": true,
+										"value": {
+											"simple": "readinesschecklist"
+										}
+									},
+									"operator": "containsGeneral",
+									"right": {
+										"value": {
+											"simple": "dp_mp_clock_diff"
+										}
+									},
+									"type": "multiSelect"
+								}
+							]
+						],
+						"isVisible": true
+					}
+				],
+				"isVisible": true,
+				"name": "Advanced Test Configuration",
+				"query": null,
+				"queryType": "",
+				"readOnly": false,
+				"type": ""
+			}
+		]
+	},
+	"fromServerVersion": "0.0.0",
+	"group": "incident",
+	"id": "PAN-OS Network Operations - Device Upgrade",
+	"indicatorsDetails": null,
+	"indicatorsQuickView": null,
+	"itemVersion": "",
+	"locked": false,
+	"mobile": null,
+	"name": "PAN-OS Network Operations - Device Upgrade",
+	"packID": "",
+	"packName": "",
+	"quickView": null,
+	"quickViewV2": null,
+	"system": false,
+	"toServerVersion": "99.99.99",
+	"version": -1
 }

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Upgrade_Assurance_Layout.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-PAN-OS_Network_Operations_-_Upgrade_Assurance_Layout.json
@@ -45,10 +45,10 @@
 							},
 							{
 								"endCol": 2,
-								"fieldId": "panosnetworkoperationsupgradetargetfirewallversion",
+								"fieldId": "panosnetworkoperationsupgradetargetversion",
 								"height": 53,
-								"id": "cfd99ad0-ea3e-11ed-939f-4f8b882605d4",
-								"index": 1,
+								"id": "ab0ddd00-74e5-11ef-9a5f-8578e5a6051d",
+								"index": 2,
 								"sectionItemType": "field",
 								"startCol": 0
 							}
@@ -550,7 +550,7 @@
 						"isVisible": true
 					},
 					{
-						"fieldId": "incident_panosnetworkoperationsupgradetargetfirewallversion",
+						"fieldId": "incident_panosnetworkoperationsupgradetargetversion",
 						"isVisible": true
 					},
 					{

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Device_Upgrade.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Device_Upgrade.yml
@@ -296,20 +296,22 @@ tasks:
       reset_ha_topology:
         simple: "true"
       target_device:
-        simple: ${incident.panosnetworkoperationstarget}
+        simple: ${inputs.target_device}
       target_version:
         simple: ${incident.upgradepath}
     separatecontext: true
     skipunavailable: false
     task:
       brand: ""
-      id: e0c5f1f3-dfea-4556-8ce3-11740cbda7de
+      description: Upgrades a single or HA pair of PAN-OS firewalls, supports running
+        as a subplaybook and be looped over to complete an entire upgrade path.
+      id: 50dc3546-d006-401d-8d15-2784e25adb2e
       iscommand: false
       name: PAN-OS Network Operations - Device Upgrade Loop
       playbookId: PAN-OS Network Operations - Device Upgrade Loop
       type: playbook
       version: -1
-    taskid: e0c5f1f3-dfea-4556-8ce3-11740cbda7de
+    taskid: 50dc3546-d006-401d-8d15-2784e25adb2e
     timertriggers: []
     type: playbook
     view: |-

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Upgrade_Assurance_-_HA_Test.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Upgrade_Assurance_-_HA_Test.yml
@@ -896,11 +896,20 @@ tasks:
       candidate_version:
         simple: ${incident.panosnetworkoperationsupgradetargetversion}
       check_list:
-        simple: panorama,ntp_sync,candidate_config,active_support
+        simple: ${incident=foo(val); function foo(incident) { const chkl = incident.readinesschecklist;
+          if (Array.isArray(chkl)) { return chkl.filter(item => item !== 'ha'); }
+          else { return ['panorama','ntp_sync','candidate_config','active_support'];
+          } } }
       check_session_exists:
         simple: ${incident.checksessionexists}
+      dp_mp_clock_diff:
+        simple: ${incident=foo(val); function foo(incident) { const chkl = incident.readinesschecklist;
+          const dpmp = incident.dpmpclockdiff; if (chkl.indexOf("dp_mp_clock_diff")>=0)
+          { return dpmp; } else { return null; } } }
       firewall_serial:
         simple: ${inputs.target}
+      ipsec_tunnel_status:
+        simple: ${incident.ipsectunnel}
       min_content_version:
         simple: ${incident.minimumcontentversion}
     separatecontext: false


### PR DESCRIPTION
## Description

This PR provides adds Assurance Tests configuration to the Device Upgrade new incident layout, similarly to the Upgrade Assurance incident layout.

* Added section in Device Upgrade new incident layout for Upgrade Assurance Tests to select desired checks and do customizations
* Test inputs for optional checks are displayed automatically if relevant test is selected in the check list. 
* Standardize use of target device and version incident fields in Device Upgrade and Upgrade Assurance layouts/playbooks so both use the same field types.
* Customized readiness checklist is also included in the HA post failover readiness checks(excluding ha check). A default set of checks are run if not provided.

## Motivation and Context

It wasn't possible to customize which readiness checks to run in Device Upgrade incidents.

## How Has This Been Tested?

Tested on vm-series firewalls.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
