### PR TITLE
Skip upgrade if target version same

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Device_Upgrade.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Device_Upgrade.yml
@@ -237,7 +237,7 @@ tasks:
       wait: 1
     nexttasks:
       '#none#':
-      - "62"
+      - "68"
     note: false
     quietmode: 0
     scriptarguments:
@@ -289,7 +289,7 @@ tasks:
       {
         "position": {
           "x": 520,
-          "y": -1370
+          "y": -1170
         }
       }
   "62":
@@ -337,7 +337,7 @@ tasks:
       {
         "position": {
           "x": 520,
-          "y": -1550
+          "y": -1330
         }
       }
   "63":
@@ -400,8 +400,7 @@ tasks:
     skipunavailable: false
     task:
       brand: ""
-      description: 'This will set the Panorama instance field (panosnetworkoperationspanoramainstance)
-        if it isn''t already set.  '
+      description: "This will set the Panorama instance field (panosnetworkoperationspanoramainstance) if it isn't already set.  "
       id: d9814a7d-ab6a-4a7d-8a00-4835e6f58a06
       iscommand: false
       name: Set Panorama Instance
@@ -418,14 +417,86 @@ tasks:
           "y": -1930
         }
       }
-version: 10
+  "68":
+    conditions:
+    - condition:
+      - - left:
+            iscontext: true
+            value:
+              simple: incident.upgradepath
+          operator: isNotEmpty
+      label: yes
+    continueonerrortype: ""
+    id: "68"
+    ignoreworker: false
+    isautoswitchedtoquietmode: false
+    isoversize: false
+    nexttasks:
+      '#default#':
+      - "69"
+      yes:
+      - "62"
+    note: false
+    quietmode: 0
+    separatecontext: false
+    skipunavailable: false
+    task:
+      brand: ""
+      id: c85aeeab-1823-426f-8828-c8303f531d6b
+      iscommand: false
+      name: Is upgrade path set?
+      type: condition
+      version: -1
+    taskid: c85aeeab-1823-426f-8828-c8303f531d6b
+    timertriggers: []
+    type: condition
+    view: |-
+      {
+        "position": {
+          "x": 520,
+          "y": -1540
+        }
+      }
+  "69":
+    continueonerrortype: ""
+    id: "69"
+    ignoreworker: false
+    isautoswitchedtoquietmode: false
+    isoversize: false
+    note: false
+    quietmode: 0
+    scriptarguments:
+      message:
+        simple: No upgradepath set, make sure to select an higher PAN-OS version than the target firewall; or if you are upgrading a partially upgraded HA pair, target firewall with the lower version.
+    separatecontext: false
+    skipunavailable: false
+    task:
+      brand: ""
+      description: Prints an error entry with a given message
+      id: 340aeda1-f805-49e6-80ef-dd86d0fbf796
+      iscommand: false
+      name: No Upgrade Path Found.
+      script: PrintErrorEntry
+      type: regular
+      version: -1
+    taskid: 340aeda1-f805-49e6-80ef-dd86d0fbf796
+    timertriggers: []
+    type: regular
+    view: |-
+      {
+        "position": {
+          "x": 980,
+          "y": -1330
+        }
+      }
+version: 11
 view: |-
   {
     "linkLabelsPosition": {},
     "paper": {
       "dimensions": {
-        "height": 1765,
-        "width": 610,
+        "height": 1965,
+        "width": 840,
         "x": 520,
         "y": -3070
       }

--- a/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Single_Device_Upgrade.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Playbooks/PAN-OS_Network_Operations_-_Single_Device_Upgrade.yml
@@ -40,8 +40,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -2110
+          "x": 265,
+          "y": 50
         }
       }
   "14":
@@ -81,8 +81,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -65
+          "x": 152.5,
+          "y": 2295
         }
       }
   "15":
@@ -137,8 +137,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": 300
+          "x": 152.5,
+          "y": 2645
         }
       }
   "16":
@@ -165,8 +165,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": 825
+          "x": 480,
+          "y": 3185
         }
       }
   "18":
@@ -202,8 +202,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": 450
+          "x": 152.5,
+          "y": 2820
         }
       }
   "19":
@@ -247,8 +247,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": 630
+          "x": 152.5,
+          "y": 2995
         }
       }
   "20":
@@ -280,8 +280,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 910,
-          "y": 810
+          "x": 50,
+          "y": 3170
         }
       }
   "21":
@@ -315,8 +315,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": 110
+          "x": 152.5,
+          "y": 2470
         }
       }
   "22":
@@ -352,8 +352,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1460
+          "x": 152.5,
+          "y": 895
         }
       }
   "23":
@@ -406,8 +406,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -760
+          "x": 152.5,
+          "y": 1595
         }
       }
   "24":
@@ -445,8 +445,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1640
+          "x": 265,
+          "y": 720
         }
       }
   "25":
@@ -457,7 +457,7 @@ tasks:
     isoversize: false
     nexttasks:
       '#none#':
-      - "26"
+      - "41"
     note: false
     quietmode: 0
     scriptarguments:
@@ -482,8 +482,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1980
+          "x": 265,
+          "y": 195
         }
       }
   "26":
@@ -526,8 +526,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1830
+          "x": 152.5,
+          "y": 545
         }
       }
   "27":
@@ -579,8 +579,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1110
+          "x": 152.5,
+          "y": 1245
         }
       }
   "35":
@@ -642,8 +642,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -1300
+          "x": 152.5,
+          "y": 1070
         }
       }
   "37":
@@ -684,8 +684,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 690,
-          "y": -930
+          "x": 265,
+          "y": 1420
         }
       }
   "38":
@@ -726,8 +726,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 690,
-          "y": -565
+          "x": 265,
+          "y": 1770
         }
       }
   "39":
@@ -768,8 +768,8 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -375
+          "x": 152.5,
+          "y": 1945
         }
       }
   "40":
@@ -803,11 +803,56 @@ tasks:
     view: |-
       {
         "position": {
-          "x": 450,
-          "y": -220
+          "x": 152.5,
+          "y": 2120
         }
       }
-version: 7
+  "41":
+    conditions:
+    - condition:
+      - - left:
+            iscontext: true
+            value:
+              simple: PANOS.ShowSystemInfo.Result.sw_version
+          operator: isEqualString
+          right:
+            iscontext: true
+            value:
+              simple: inputs.target_version
+      label: yes
+    continueonerrortype: ""
+    id: "41"
+    ignoreworker: false
+    isautoswitchedtoquietmode: false
+    isoversize: false
+    nexttasks:
+      '#default#':
+      - "26"
+      yes:
+      - "16"
+    note: false
+    quietmode: 0
+    separatecontext: false
+    skipunavailable: false
+    task:
+      brand: ""
+      description: Checks whether the post-upgrade software version is correct.
+      id: f3a2da69-8f2f-4869-8210-6b027538e17d
+      iscommand: false
+      name: Check if System already running requested version
+      type: condition
+      version: -1
+    taskid: f3a2da69-8f2f-4869-8210-6b027538e17d
+    timertriggers: []
+    type: condition
+    view: |-
+      {
+        "position": {
+          "x": 265,
+          "y": 370
+        }
+      }
+version: 8
 view: |-
   {
     "linkLabelsPosition": {
@@ -815,10 +860,10 @@ view: |-
     },
     "paper": {
       "dimensions": {
-        "height": 3015,
-        "width": 840,
-        "x": 450,
-        "y": -2110
+        "height": 3215,
+        "width": 810,
+        "x": 50,
+        "y": 50
       }
     }
   }

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/FilterAvailableSoftwareImages/FilterAvailableSoftwareImages.py
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/FilterAvailableSoftwareImages/FilterAvailableSoftwareImages.py
@@ -1,4 +1,4 @@
-import demistomock as demisto
+import demistomock as demisto  # noqa: F401
 from CommonServerPython import *  # noqa: F401
 
 """
@@ -75,10 +75,14 @@ def check_if_feature_version_update(left_image_version: str, right_image_version
             return left_image_version
 
 
-def get_minor_version_as_float(minor_version_str: str):
-    minor_version_str = minor_version_str.replace("-h", ".")
-    minor_version_str = minor_version_str.replace("-b", ".")
-    return float(minor_version_str)
+def get_hotfix_version(minor_version_str: str):
+    if len(minor_version_str.split("-")) == 2:
+        minor_version_hotfix = minor_version_str.split("-")[-1]
+        minor_version_hotfix = minor_version_hotfix.replace("h", "")
+        minor_version_hotfix = minor_version_hotfix.replace("b", "")
+        return int(minor_version_hotfix)
+    else:
+        return 0
 
 
 def check_if_minor_version_update(left_image_version: str, right_image_version: str):
@@ -96,10 +100,16 @@ def check_if_minor_version_update(left_image_version: str, right_image_version: 
     left_minor_version = left_image_version.split(".")[-1]
     right_minor_version = right_image_version.split(".")[-1]
 
+    left_minor_version_wo_hotfix = int(left_minor_version.split("-")[0])
+    right_minor_version_wo_hotfix = int(right_minor_version.split("-")[0])
+
     if (left_major_version, left_feature_version) == (right_major_version, right_feature_version):
         # Any software images that share the major and feature releases are valid targets.
-        if get_minor_version_as_float(left_minor_version) < get_minor_version_as_float(right_minor_version):
+        if left_minor_version_wo_hotfix < right_minor_version_wo_hotfix:
             return left_image_version
+        elif left_minor_version_wo_hotfix == right_minor_version_wo_hotfix:
+            if get_hotfix_version(left_minor_version) < get_hotfix_version(right_minor_version):
+                return left_image_version
 
 
 def check_if_major_version_update(left_image_version: str, right_image_version: str, any_version_jump=False):


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Skip re-installing software if target version matches with installed version on firewall.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows upgrading a partially upgraded HA pair if upgrade playbook failed after upgrading a peer.
The firewall with lower panos version should be targeted when creating a new device upgrade incident to upgrade a partially upgraded HA pair.
Also fixes #50 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on vmseries with xsoar 8.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
