### PR TITLE
Network Device indicator create incident buttons with tests

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -264,7 +264,8 @@ def command_run_readiness_checks(panorama: Panorama):
 
     # this will set it to [] if emptry string or not provided - meaning check all
     check_list = argToList(args.get('check_list'))
-    if args.get('check_list') is not None:
+    # remove check_list from args to avoid duplicate arg pass to run_readiness_checks
+    if 'check_list' in args:
         del args['check_list']
 
     if 'dp_mp_clock_diff' in check_list:
@@ -273,7 +274,7 @@ def command_run_readiness_checks(panorama: Panorama):
 
     # this will set it to None if emptry string or not provided
     dp_mp_clock_diff = arg_to_number(args.get('dp_mp_clock_diff'), required=False)
-    if args.get('dp_mp_clock_diff') is not None:
+    if 'dp_mp_clock_diff' in args:
         del args['dp_mp_clock_diff']
 
     if 'ipsec_tunnel' in check_list:
@@ -284,7 +285,7 @@ def command_run_readiness_checks(panorama: Panorama):
         check_list.remove('arp')
         check_list.append('arp_entry_exists')
 
-    if (arp_entry := args.get('arp_entry_exists')) is not None and not is_ip_valid(arp_entry):
+    if (arp_entry := args.get('arp_entry_exists')) and not is_ip_valid(arp_entry):
         raise ValueError(
             f"{arp_entry} is not a valid IPv4 address."
         )
@@ -315,7 +316,7 @@ def command_run_snapshot(panorama: Panorama):
 
     # this will set it to [] if emptry string or not provided - meaning all snapshots
     snapshot_list = argToList(args.get('check_list'))
-    if args.get('check_list') is not None:
+    if 'check_list' in args:
         del args['check_list']
 
     snapshot = run_snapshot(firewall, snapshot_list, **args)

--- a/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-Network_Device_Layout.json
+++ b/Packs/PAN_OS_Upgrade_Services/Layouts/layoutscontainer-Network_Device_Layout.json
@@ -104,8 +104,32 @@
 						"items": [
 							{
 								"args": {
+									"arp_entry_exists": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"dp_mp_clock_diff": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
 									"incident_type": {
 										"simple": "PAN-OS Network Operations - Device Upgrade"
+									},
+									"ipsec_tunnel": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"min_content_version": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"readiness_checklist": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"session_exists": {
+										"simple": "",
+										"userMarkedRequired": true
 									}
 								},
 								"buttonClass": "warning",
@@ -115,24 +139,48 @@
 								"id": "dc989cd0-0c8b-11ed-a0b8-eb2ebd0d1561",
 								"index": 0,
 								"name": "Upgrade Device Software",
-								"scriptId": "CreateNetopsIncidentButton",
+								"scriptId": "CreateCustomizedNetopsIncidentButton",
 								"sectionItemType": "button",
 								"startCol": 0
 							},
 							{
 								"args": {
+									"arp_entry_exists": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"dp_mp_clock_diff": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
 									"incident_type": {
 										"simple": "PAN-OS Network Operations - Upgrade Assurance"
+									},
+									"ipsec_tunnel": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"min_content_version": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"readiness_checklist": {
+										"simple": "",
+										"userMarkedRequired": true
+									},
+									"session_exists": {
+										"simple": "",
+										"userMarkedRequired": true
 									}
 								},
 								"buttonClass": "warning",
 								"endCol": 2,
 								"fieldId": "",
-								"height": 22,
+								"height": 44,
 								"id": "8ef6c680-eb03-11ed-bf79-1d5359b4825d",
 								"index": 1,
 								"name": "Run Upgrade Assurance Testing",
-								"scriptId": "CreateNetopsIncidentButton",
+								"scriptId": "CreateCustomizedNetopsIncidentButton",
 								"sectionItemType": "button",
 								"startCol": 0
 							}

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.py
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.py
@@ -1,0 +1,55 @@
+import demistomock as demisto  # noqa: F401
+from CommonServerPython import *  # noqa: F401
+
+
+
+"""
+This script is executed whenever an associated button in the Network Device indicator layout is pressed.
+"""
+
+
+def main():
+    args = demisto.args()
+    indicator = args.get("indicator")
+    target = str(indicator["value"])
+    # Target for Panorama Device will be IP, not serial.
+    if indicator.get("indicator_type") == "Panorama Device":
+        target = str(indicator.get("CustomFields").get("panoramahostname"))
+        if not target:
+            target = str(indicator.get("CustomFields").get("ipaddress"))
+
+    incident_type = args.get("incident_type")
+    readiness_checklist = args.get("readiness_checklist")
+    min_content_version = args.get("min_content_version")
+    arp_entry_exists = args.get("arp_entry_exists")
+    session_exists = args.get("session_exists")
+    ipsec_tunnel = args.get("ipsec_tunnel")
+    dp_mp_clock_diff = args.get("dp_mp_clock_diff")
+
+    # Get pan-os instance name
+    panos = str(indicator.get("CustomFields").get('panoramainstance'))
+
+    res = demisto.executeCommand("createNewIncident", {
+        "name": f"{target} - {incident_type}",
+        "type": incident_type,
+        "panosnetworkoperationstarget": target,
+        "panosnetworkoperationspanoramainstance": panos,
+        "readinesschecklist": readiness_checklist,
+        "minimumcontentversion": min_content_version,
+        "checkarpentryexists": arp_entry_exists,
+        "checksessionexists": session_exists,
+        "ipsectunnel": ipsec_tunnel,
+        "dpmpclockdiff": dp_mp_clock_diff
+    })
+
+    created_incident = res[0]
+    id = created_incident.get("EntryContext", dict()).get("CreatedIncidentID")
+
+    demisto.executeCommand("associateIndicatorToIncident", {"incidentId": id, "value": indicator["value"]})
+
+
+''' ENTRY POINT '''
+
+
+if __name__ in ('__main__', '__builtin__', 'builtins'):
+    main()

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.yml
@@ -1,0 +1,49 @@
+args:
+- description: incident type
+  isArray: true
+  name: incident_type
+  required: true
+- auto: PREDEFINED
+  description: The list of checks to run. Checks with inputs are skipped if relevant check is not selected in the checklist.
+  isArray: true
+  name: readiness_checklist
+  predefined:
+  - panorama
+  - ntp_sync
+  - ha
+  - candidate_config
+  - expired_licenses
+  - active_support
+  - content_version
+  - session_exist
+  - arp
+  - ipsec_tunnel
+  - dp_mp_clock_diff
+- description: The minimum content version to test against. Checks for latest content version if not provided.
+  name: min_content_version
+- description: Checks if the given IP is in the ARP table before starting upgrade.
+  name: arp_entry_exists
+- description: Check for the presence of a specific session in the session table before upgrade starts (source_ip/destination_ip/port).
+  name: session_exists
+- description: IPsec tunnel name to check if it's in active state.
+  name: ipsec_tunnel
+- description: Max. clock difference in seconds between data plane and management plane.
+  name: dp_mp_clock_diff
+comment: Indicator layout button to create customized panos netops incidents.
+commonfields:
+  id: 'CreateCustomizedNetopsIncidentButton'
+  version: -1
+dockerimage: demisto/python3:3.11.10.113941
+enabled: true
+engineinfo: {}
+mainengineinfo: {}
+name: CreateCustomizedNetopsIncidentButton
+pswd: ""
+runas: DBotWeakRole
+runonce: false
+script: ''
+scripttarget: 0
+subtype: python3
+tags:
+- indicator-action-button
+type: python


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds functionality to customize assurance test configuration on "Upgrade Device Software" and "Run Upgrade Assurance Testing" button click in the Network Device indicator page.

CreateCustomizedNetopsIncidentButton script is introduced to be able to create Device Upgrade and Upgrade Assurance incidents with assurance test configuration.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change makes it possible to customize upgrade assurance tests if incidents are created via the "Upgrade Device Software" and "Run Upgrade Assurance Testing" buttons  in the Network Device indicator page. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on XSOAR 8 with VMSeries HA.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->
![image](https://github.com/user-attachments/assets/0214f1e2-a613-4fa7-9cb7-bf9801449cab)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
