### PR TITLE
bgp_peers added to assurance snapshot checklist

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/IncidentFields/incidentfield-Snapshot_Check_List.json
+++ b/Packs/PAN_OS_Upgrade_Services/IncidentFields/incidentfield-Snapshot_Check_List.json
@@ -48,7 +48,8 @@
 		"arp_table",
 		"content_version",
 		"session_stats",
-		"ip_sec_tunnels"
+		"ip_sec_tunnels",
+		"bgp_peers"
 	],
 	"selectValuesMap": null,
 	"sla": 0,

--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -62,6 +62,7 @@ def run_snapshot(
     """Runs a snapshot and saves it as a JSON file in the XSOAR system."""
 
     if not snapshot_list:
+        # this is the default list while other snapshot types can be passed in the argument
         snapshot_list = [
             'nics',
             'routes',
@@ -272,6 +273,9 @@ def compare_snapshots(left_snapshot, right_snapshot,
                 'properties': ['state']
             }
         })
+
+    if 'bgp_peers' in snapshot_list:
+        snapshot_comparisons.append('bgp_peers')
 
     return snapshot_compare.compare_snapshots(snapshot_comparisons)
 

--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -275,7 +275,11 @@ def compare_snapshots(left_snapshot, right_snapshot,
         })
 
     if 'bgp_peers' in snapshot_list:
-        snapshot_comparisons.append('bgp_peers')
+        snapshot_comparisons.append({
+            'bgp_peers': {
+                'properties': ['status']
+            }
+        })
 
     return snapshot_compare.compare_snapshots(snapshot_comparisons)
 

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.yml
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/CreateCustomizedNetopsIncidentButton/CreateCustomizedNetopsIncidentButton.yml
@@ -41,6 +41,7 @@ args:
   - content_version
   - session_stats
   - ip_sec_tunnels
+  - bgp_peers
 - description: Percentage of change in session stats that is allowed to pass the comparison.
   name: session_stats_threshold
 comment: Indicator layout button to create customized panos netops incidents.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adding `bgp_peers` snapshot type to the list of assurance snapshot checklist to allow bgp peers comparison.
This PR also covers the #27 PR without adding `bgp_peers` to the default checklist.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #24 but option is not added to the default checklist, should be selected in the snapshot checklist dropdown to include in the snapshots comparison.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
