### PR TITLE
feat: replace bare open() with with statements for better file handling

### DIFF
--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Device_Management/PAN_OS_Device_Management_test.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Device_Management/PAN_OS_Device_Management_test.py
@@ -21,14 +21,14 @@ def load_xml_root_from_test_file(xml_file: str):
 def load_json_from_test_file(file_name):
     """Given a JSON file, returns the contents"""
     try:
-        data = json.load(open(file_name))
+        with open(file_name) as f:
+            data = json.load(f)
     except FileNotFoundError:
         # Handle test being run outside of test directory (i.e from content root dir)
-        data = json.load(
-            open(TEST_LOCATION_FROM_ROOT + file_name))
-
+        with open(TEST_LOCATION_FROM_ROOT + file_name) as f:
+            data = json.load(f)
+    
     return data
-
 
 @pytest.fixture
 def integration_test_fixture():

--- a/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
+++ b/Packs/PAN_OS_Upgrade_Services/Integrations/PAN_OS_Upgrade_Assurance/PAN_OS_Upgrade_Assurance.py
@@ -26,7 +26,8 @@ def get_file_path(input_entry_id):
 
 def read_file_by_id(input_entry_id):
     fp = get_file_path(input_entry_id)
-    return json.load(open(fp))
+    with open(fp) as f:
+        return json.load(f)
 
 
 def get_firewall_object(panorama: Panorama, serial_number):

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/FilterAvailableSoftwareImages/FilterAvailableSoftwareImages_test.py
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/FilterAvailableSoftwareImages/FilterAvailableSoftwareImages_test.py
@@ -136,7 +136,11 @@ def test_main():
     pytest.skip(
         "Might contain sensitive data. To run this unit test, copy output from pan-os-available-software."
     )
-    available_images = json.load(open("test_data/all_available_software.json"))
-    installed_images = json.load(open("test_data/installed_images.json"))
+    with open("test_data/all_available_software.json") as f:
+        available_images = json.load(f)
+        
+    with open("test_data/installed_images.json") as f:
+        installed_images = json.load(f)
+
     from FilterAvailableSoftwareImages import main
     result = main(installed_images, available_images)

--- a/Packs/PAN_OS_Upgrade_Services/Scripts/GroupIssuesByFields/GroupIssuesByFields_test.py
+++ b/Packs/PAN_OS_Upgrade_Services/Scripts/GroupIssuesByFields/GroupIssuesByFields_test.py
@@ -6,12 +6,13 @@ TEST_LOCATION_FROM_ROOT = "Packs/PAN_OS_Upgrade_Services/Scripts/GroupIssuesByFi
 def load_json_from_test_file(file_name):
     """Given a JSON file, returns the contents"""
     try:
-        data = json.load(open(file_name))
+        with open(file_name) as f:
+            data = json.load(f)
     except FileNotFoundError:
         # Handle test being run outside of test directory (i.e from content root dir)
-        data = json.load(
-            open(TEST_LOCATION_FROM_ROOT + file_name))
-
+        with open(TEST_LOCATION_FROM_ROOT + file_name) as f:
+            data = json.load(f)
+    
     return data
 
 


### PR DESCRIPTION
# Improve File Handling with `with` Statements

## What’s Changed
I’ve updated the codebase to replace bare `open()` calls with `with` statements in several functions (`load_json_from_test_file`, `read_file_by_id`, and `test_main`). This ensures files are properly closed after use, even if exceptions occur.

## Why It Matters
Using `with` statements is a Python best practice that:
- Prevents resource leaks by automatically closing files
- Makes the code more robust against unexpected errors
- Aligns with modern Python conventions

The original code worked fine, but this change adds a layer of safety and reliability—especially important when dealing with file operations that might fail in unpredictable ways.

Please, take a look, I’d love to hear your thoughts! I think this small tweak makes our code cleaner and more dependable. Let me know if there’s anything you’d like me to adjust. Thanks for considering it!